### PR TITLE
chore(docs): repo-wide markdownlint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ dist
 !.yarn/versions
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+
+# Trust policy (example tracked, real file ignored)
+trust.json

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.git
+**/pkg/**
+**/generated/**
+

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "test": "node --test ./test/*.mjs",
     "daemon:start": "SGN_DB=./sgn.db SGN_HTTP_PORT=8787 node src/daemon/daemon.mjs",
     "daemon:health": "curl -s http://localhost:8787/health",
-    "md:lint": "markdownlint \"**/*.md\" --ignore node_modules --ignore dist --ignore .git",
-    "md:fix": "markdownlint \"**/*.md\" --fix --ignore node_modules --ignore dist --ignore .git"
+    "md:lint": "npx markdownlint \"**/*.md\" --ignore node_modules --ignore dist --ignore .git --ignore \"**/pkg/**\" --ignore \"**/generated/**\"",
+    "md:fix": "npx markdownlint \"**/*.md\" --fix --ignore node_modules --ignore dist --ignore .git --ignore \"**/pkg/**\" --ignore \"**/generated/**\""
   },
   "keywords": [],
   "author": "",
@@ -41,5 +41,6 @@
   "devDependencies": {
     "fast-check": "^4.2.0",
     "markdownlint-cli": "^0.45.0"
+  }
   }
 }


### PR DESCRIPTION
This PR introduces repo-wide markdownlint configuration and a first normalization pass.

- Adds .markdownlint.json and .markdownlintignore
- Adds npm scripts: md:lint, md:fix (using npx)
- Adds CI workflow .github/workflows/mdlint.yml to lint on PRs
- Applies initial automated fixes to markdown files (leaves some MD013 cases as-is)

Run locally:
```bash
npm run md:fix && npm run md:lint
```


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author